### PR TITLE
Reordered syntax definitions

### DIFF
--- a/Stan.JSON-tmLanguage
+++ b/Stan.JSON-tmLanguage
@@ -17,9 +17,9 @@
         {"include": "#string"},
 
         {"include": "#type"},
-        {"include": "#cpp-conflict"},
         {"include": "#range"},
         {"include": "#control-flow"},
+        {"include": "#cpp-conflict"},
 
         {"include": "#distributions"},
         {"include": "#cdfs"},
@@ -100,9 +100,9 @@
         {"include": "#string"},
 
         {"include": "#type"},
-        {"include": "#cpp-conflict"},
         {"include": "#range"},
         {"include": "#control-flow"},
+        {"include": "#cpp-conflict"},
 
         {"include": "#distributions"},
         {"include": "#cdfs"},

--- a/Stan.tmLanguage
+++ b/Stan.tmLanguage
@@ -61,15 +61,15 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#cpp-conflict</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#range</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>#control-flow</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#cpp-conflict</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -166,15 +166,15 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#cpp-conflict</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#range</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>#control-flow</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#cpp-conflict</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
This way, control flows are highlighted before C++ reserved word conflicts.

Previously, I was getting any 'if' statement highlighted as a conflict.
