### PR TITLE
Reverse precedence of comment symbols

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -14,13 +14,13 @@
             <key>name</key>
             <string>TM_COMMENT_START</string>
             <key>value</key>
-            <string># </string>
+            <string>// </string>
          </dict>
          <dict>
             <key>name</key>
             <string>TM_COMMENT_START_2</string>
             <key>value</key>
-            <string>// </string>
+            <string># </string>
          </dict>
          <dict>
             <key>name</key>


### PR DESCRIPTION
Warning messages from Stan indicate that comments beginning with # are deprecated and that // is recommended. This commit makes // the automatic comment symbol so that shortcuts (super+/) print the recommended comment character  :-)